### PR TITLE
Add sessionToken param to NewEC2Provisioner

### DIFF
--- a/provision/ec2.go
+++ b/provision/ec2.go
@@ -18,10 +18,10 @@ type EC2Provisioner struct {
 }
 
 // NewEC2Provisioner creates an EC2Provisioner and initialises an EC2 client
-func NewEC2Provisioner(region, accessKey, secretKey string) (*EC2Provisioner, error) {
+func NewEC2Provisioner(region, accessKey, secretKey, sessionToken string) (*EC2Provisioner, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region:      aws.String(region),
-		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
+		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, sessionToken),
 	})
 	svc := ec2.New(sess)
 	return &EC2Provisioner{ec2Provisioner: svc}, err


### PR DESCRIPTION
Currently the session token field is defaulted to "".
This makes it impossible to use temporary session creds
in inletsctl as AWS expects key, secret & token.

This change adds a new parameter to NewEC2Provisioner
to pass the session token through which is subsequenty
used in NewStaticCredentials.

Signed-off-by: Richard Gee <richard@technologee.co.uk>