### PR TITLE
Fix regression for added extra ports to EC2 security group

### DIFF
--- a/provision/ec2.go
+++ b/provision/ec2.go
@@ -270,6 +270,8 @@ func (p *EC2Provisioner) createEC2SecurityGroup(vpcID string, controlPort int, o
 	if len(extraPorts) > 0 {
 		// disable high port range if extra ports are specified
 		highPortRange = []int{}
+
+		ports = append(ports, extraPorts...)
 	}
 
 	groupName := "inlets-" + uuid.New().String()

--- a/provision/gce_test.go
+++ b/provision/gce_test.go
@@ -6,16 +6,18 @@ func TestCustomGCEIDConstAndDest(t *testing.T) {
 	inputInstanceName := "inlets"
 	inputZone := "us-central1-a"
 	inputProjectID := "playground"
+	inputRegion := "us-central"
 
-	customID := toGCEID(inputInstanceName, inputZone, inputProjectID)
+	customID := toGCEID(inputInstanceName, inputZone, inputProjectID, inputRegion)
 
-	outputInstanceName, outputZone, outputProjectID, err := getGCEFieldsFromID(customID)
+	outputInstanceName, outputZone, outputProjectID, outputRegion, err := getGCEFieldsFromID(customID)
 	if err != nil {
 		t.Error(err)
 	}
 	if inputInstanceName != outputInstanceName ||
 		inputZone != outputZone ||
-		inputProjectID != outputProjectID {
+		inputProjectID != outputProjectID ||
+		inputRegion != outputRegion {
 		t.Errorf("Input fields: %s, %s, %s are not equal to the ouput fields: %s, %s, %s",
 			inputInstanceName, inputZone, inputProjectID, outputInstanceName, outputZone, outputProjectID)
 	}


### PR DESCRIPTION
## Description

Adding extra ports to the EC2  security group was added as a feature.  This PR fixes a regression introduced by https://github.com/inlets/cloud-provision/commit/ac3b8b4c3537806280c1539584b99b1af6cb7218

## How Has This Been Tested?

Used with inletsctl and verified extra ports are to the security group for an EC2 instance.