### PR TITLE
Add support for setting Proxy Protocol in exit server userdata

### DIFF
--- a/provision/userdata.go
+++ b/provision/userdata.go
@@ -3,10 +3,18 @@ package provision
 // MakeExitServerUserdata makes a user-data script in bash to setup inlets
 // PRO with a systemd service and the given version.
 func MakeExitServerUserdata(authToken, version string) string {
+	return MakeExitServerUserdataWithProxyProto(authToken, version, "")
+}
+
+// MakeExitServerUserdataWithProxyProto makes a user-data script in bash to setup inlets
+// PRO with a systemd service and the given version. If proxyProto is non-empty,
+// the PROXY_PROTO environment variable is set in the service configuration.
+func MakeExitServerUserdataWithProxyProto(authToken, version, proxyProto string) string {
 
 	return `#!/bin/bash
 export AUTHTOKEN="` + authToken + `"
 export IP=$(curl -sfSL https://checkip.amazonaws.com)
+export PROXY_PROTO="` + proxyProto + `"
 
 curl -SLsf https://github.com/inlets/inlets-pro/releases/download/` + version + `/inlets-pro -o /tmp/inlets-pro && \
   chmod +x /tmp/inlets-pro  && \
@@ -16,6 +24,7 @@ curl -SLsf https://github.com/inlets/inlets-pro/releases/download/` + version + 
   mv inlets-pro.service /etc/systemd/system/inlets-pro.service && \
   echo "AUTHTOKEN=$AUTHTOKEN" >> /etc/default/inlets-pro && \
   echo "IP=$IP" >> /etc/default/inlets-pro && \
+  echo "PROXY_PROTO=$PROXY_PROTO" >> /etc/default/inlets-pro && \
   systemctl daemon-reload && \
   systemctl start inlets-pro && \
   systemctl enable inlets-pro

--- a/provision/userdata_test.go
+++ b/provision/userdata_test.go
@@ -13,6 +13,7 @@ func Test_makeUserdata_InletsPro(t *testing.T) {
 	wantUserdata := `#!/bin/bash
 export AUTHTOKEN="auth"
 export IP=$(curl -sfSL https://checkip.amazonaws.com)
+export PROXY_PROTO=""
 
 curl -SLsf https://github.com/inlets/inlets-pro/releases/download/0.7.0/inlets-pro -o /tmp/inlets-pro && \
   chmod +x /tmp/inlets-pro  && \
@@ -22,12 +23,40 @@ curl -SLsf https://github.com/inlets/inlets-pro/releases/download/0.7.0/inlets-p
   mv inlets-pro.service /etc/systemd/system/inlets-pro.service && \
   echo "AUTHTOKEN=$AUTHTOKEN" >> /etc/default/inlets-pro && \
   echo "IP=$IP" >> /etc/default/inlets-pro && \
+  echo "PROXY_PROTO=$PROXY_PROTO" >> /etc/default/inlets-pro && \
   systemctl daemon-reload && \
   systemctl start inlets-pro && \
   systemctl enable inlets-pro
 `
 
 	// ioutil.WriteFile("/tmp/pro", []byte(userData), 0600)
+	if userData != wantUserdata {
+		t.Errorf("want: %s, but got: %s", wantUserdata, userData)
+	}
+}
+
+func Test_makeUserdata_InletsPro_WithProxyProto(t *testing.T) {
+	userData := MakeExitServerUserdataWithProxyProto("auth", "0.7.0", "v1")
+
+	wantUserdata := `#!/bin/bash
+export AUTHTOKEN="auth"
+export IP=$(curl -sfSL https://checkip.amazonaws.com)
+export PROXY_PROTO="v1"
+
+curl -SLsf https://github.com/inlets/inlets-pro/releases/download/0.7.0/inlets-pro -o /tmp/inlets-pro && \
+  chmod +x /tmp/inlets-pro  && \
+  mv /tmp/inlets-pro /usr/local/bin/inlets-pro
+
+curl -SLsf https://github.com/inlets/inlets-pro/releases/download/0.7.0/inlets-pro.service -o inlets-pro.service && \
+  mv inlets-pro.service /etc/systemd/system/inlets-pro.service && \
+  echo "AUTHTOKEN=$AUTHTOKEN" >> /etc/default/inlets-pro && \
+  echo "IP=$IP" >> /etc/default/inlets-pro && \
+  echo "PROXY_PROTO=$PROXY_PROTO" >> /etc/default/inlets-pro && \
+  systemctl daemon-reload && \
+  systemctl start inlets-pro && \
+  systemctl enable inlets-pro
+`
+
 	if userData != wantUserdata {
 		t.Errorf("want: %s, but got: %s", wantUserdata, userData)
 	}


### PR DESCRIPTION
## Description

Add a `MakeExitServerUserdataWithProxyProto` function that accepts a `proxyProto` parameter and sets the `PROXY_PROTO` environment variable in the exit server userdata script. The existing `MakeExitServerUserdata` function is preserved as a wrapper with an empty default.

## Motivation and context

This is required to allow the inlets-operator to provision tunnel servers with Proxy Protocol enabled.